### PR TITLE
Ссылка на slack

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 Чат в Skype: http://bit.ly/berlin-ru-it-chat
 
-Чат в Slack: https://slack-files.com/T09S9JDU1-F0HHEG8PK-c9396c730a
+Чат в Slack: http://berlin-ru.herokuapp.com/
 
 Чат в Telegram:
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 Чат в Skype: http://bit.ly/berlin-ru-it-chat
 
-Чат в Slack: http://berlin-ru.herokuapp.com/
+Чат в Slack: berlinru.slack.com, чтобы получить инвайт заполните форму здесь berlin-ru.herokuapp.com
 
 Чат в Telegram:
 


### PR DESCRIPTION
Старая ссылка сломалась, как ее чинить не совсем ясно, файл в слаке не получается найти из-за ограничений бесплатной версии.

Есть heroku приложение, которое изначально предлагалось, ссылку на него и используем.