### PR TITLE
Добавлен берлинский чат

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@
 Чат в Telegram:
 
 - Общий чат Германия: https://t.me/tractor_de
-- Берлин: https://t.me/berlinru
+- Берлинские чаты: 
+    - https://t.me/berlinru
+    - https://t.me/berlinonline
 - Мюнхен: https://t.me/muenchentraktor
 - Франкфурт: https://t.me/mein_frankfurt
 - Гамбург: https://t.me/hamburgru


### PR DESCRIPTION
Из изменений @andron13 #541
Автор видимо пропал, ПР открыт из неизвестного источника, предположительно форк удален. Чери пик по номеру коммита сделать не выйдет.
 А такие линки будут явно полезные, я думаю это надо просто добавить.