### PR TITLE
Обновленная ссылка на буклет BSR

### DIFF
--- a/Мусор.md
+++ b/Мусор.md
@@ -6,7 +6,7 @@
 
 # Контейнеры внутри дома
 
-В большинстве домов может быть до 5 типов контейнеров (зависит от района, договора домовладельца и других вещей). Пример: Буклет BSR [Wohin mit Ihrem Abfall?](https://www.bsr.de/assets/downloads/BSR_Muellplatzschild_2016.pdf).
+В большинстве домов может быть до 5 типов контейнеров (зависит от района, договора домовладельца и других вещей). Пример: Буклет BSR [Wohin mit Ihrem Abfall?](https://www.bsr.de/assets/downloads/Barrierearme_Abfalltrennung_leichteSprache_WEB.pdf).
 
 ## Бумага и картон (Papier. Синий контейнер):
   * газеты, журналы, коробки, картон


### PR DESCRIPTION
Текущий документ дает 404, обновил ссылку на работающую.

Было два варианта:
- [Abfälle richtig trennen, Umwelt schützen (Miniflyer)](https://www.bsr.de/assets/downloads/Barrierearme_Abfalltrennung_leichteSprache_WEB.pdf)
- [Abfälle richtig trennen, Umwelt schützen (Miniflyer - leichte Sprache)](https://www.bsr.de/assets/downloads/Abfaelle_LEP_70x105_2021-04_barrierefrei_WEB.pdf)

Выбрал тот что с картинками, ибо чуть более наглядно кмк, но можно поменять и на более строгий официальный.