### PR TITLE
Update telegram chats in Berlin

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@
 
 - Общий чат Германия: <https://t.me/tractor_de>
 - Берлинские чаты:
-  - <https://t.me/berlinonline>
-  - <https://t.me/berlinru>
+  - <https://t.me/BerlinFailed>
+  - <https://t.me/berlinsob>
 - Гамбург: <https://t.me/hamburgru>
 - Мюнхен:
   - <https://t.me/muenchentraktor> - общий


### PR DESCRIPTION
Привет!

Наткнулся на репозиторий, спасибо большое за такое большое количество полезной информации.

Первым делом зашел в чатики Берлинские из README (добавлялись в 2017 по судя по Blame).

В первом 2 человека и он неактивен, в другом 300+ человек и некоторые активные юзеры из них крайне радикально настроены к новым членам чата и покрывают матом активно. Мне кажется это не тот чат, в который стоит каждому попадать и портить себе настроение, он скорее на определенных любителей рассчитан, любящих общение на политическую тему и различный оффтоп.

При этом, я добавил пару чатиков вместо них, которые активны и могут помочь русскоговорящим в Берлине найти ответ на свой вопрос.